### PR TITLE
Optimization: remove prog unbindes, to allow binding optimization

### DIFF
--- a/src/components/Rotate.jl
+++ b/src/components/Rotate.jl
@@ -235,6 +235,5 @@ function draw_rotated_texture(texture_id::UInt32, rotation_degrees::Float32, x::
 
     # Cleanup
     GLA.unbind(vao)
-    GLA.unbind(prog[])
     ModernGL.glBindTexture(ModernGL.GL_TEXTURE_2D, 0)
 end

--- a/src/components/common/draw.jl
+++ b/src/components/common/draw.jl
@@ -20,9 +20,8 @@ function draw_closed_lines(vertices::Vector{Point2f}, color_rgba::Vec4{<:Float32
     # Draw the vertices using the VAO
     GLA.draw(vao)
 
-    # Unbind the VAO and shader program
+    # Unbind the VAO
     GLA.unbind(vao)
-    GLA.unbind(prog[])
 end
 
 """
@@ -57,9 +56,8 @@ function draw_rectangle(vertices::Vector{Point2f}, color_rgba::Vec4{<:Float32}, 
     # Draw the rectangle using the VAO
     GLA.draw(vao)
 
-    # Unbind the VAO and shader program
+    # Unbind the VAO
     GLA.unbind(vao)
-    GLA.unbind(prog[])
 end
 
 """
@@ -119,7 +117,6 @@ function draw_rounded_rectangle(
     GLA.draw(vao)
 
     GLA.unbind(vao)
-    GLA.unbind(rounded_rect_prog[])
 end
 
 """
@@ -184,5 +181,4 @@ function draw_configurable_rectangle(
     GLA.draw(vao)
 
     GLA.unbind(vao)
-    GLA.unbind(configurable_rect_prog[])
 end

--- a/src/components/common/line_draw.jl
+++ b/src/components/common/line_draw.jl
@@ -153,8 +153,6 @@ function draw_line(
     GLA.draw(vao)
     GLA.unbind(vao)
 
-    # Unbind shader program
-    GLA.unbind(line_prog[])
 end
 
 """
@@ -225,9 +223,6 @@ function draw_lines(
     GLA.bind(vao)
     GLA.draw(vao)
     GLA.unbind(vao)
-
-    # Unbind shader program
-    GLA.unbind(line_prog[])
 end
 
 """

--- a/src/components/common/render_cache.jl
+++ b/src/components/common/render_cache.jl
@@ -336,6 +336,5 @@ function draw_cached_texture(texture_id::UInt32, x::Float32, y::Float32, width::
 
     # Cleanup
     GLA.unbind(vao)
-    GLA.unbind(prog[])
     ModernGL.glBindTexture(ModernGL.GL_TEXTURE_2D, 0)
 end

--- a/src/components/image/draw.jl
+++ b/src/components/image/draw.jl
@@ -54,7 +54,6 @@ function draw_image(texture::GLAbstraction.Texture, x_px::Float32, y_px::Float32
     GLA.bind(vao)
     GLA.draw(vao)
 
-    # Unbind the VAO and shader program
+    # Unbind the VAO
     GLA.unbind(vao)
-    GLA.unbind(prog[])
 end

--- a/src/components/separator_line/HorizontalLine.jl
+++ b/src/components/separator_line/HorizontalLine.jl
@@ -68,7 +68,6 @@ function interpret_view(view::HorizontalLineView, x::Float32, y::Float32, width:
     GLA.bind(vao)
     GLA.draw(vao)
     GLA.unbind(vao)
-    GLA.unbind(prog[])
 end
 
 function measure_height(view::HorizontalLineView, available_width::Float32)::Float32

--- a/src/components/separator_line/VerticalLine.jl
+++ b/src/components/separator_line/VerticalLine.jl
@@ -66,7 +66,6 @@ function interpret_view(view::VerticalLineView, x::Float32, y::Float32, width::F
     GLA.bind(vao)
     GLA.draw(vao)
     GLA.unbind(vao)
-    GLA.unbind(prog[])
 end
 
 function measure_width(view::VerticalLineView, available_height::Float32)::Float32

--- a/src/components/text/draw.jl
+++ b/src/components/text/draw.jl
@@ -108,7 +108,7 @@ function draw_glyph_from_atlas(
 
     # Unbind
     GLA.unbind(vao)
-    GLA.unbind(glyph_prog[])
+
 end
 
 """
@@ -173,7 +173,6 @@ function draw_glyph_atlas_debug(
 
     # Unbind
     GLA.unbind(vao)
-    GLA.unbind(glyph_prog[])
 end
 
 
@@ -225,7 +224,6 @@ function render_glyph_batch!(
 
     # Cleanup
     GLA.unbind(vao)
-    GLA.unbind(glyph_prog[])
 end
 
 """

--- a/src/composite_components/plot/draw/line_draw.jl
+++ b/src/composite_components/plot/draw/line_draw.jl
@@ -141,7 +141,6 @@ function draw_lines(batch::LineBatch, projection_matrix::Mat4{Float32}; anti_ali
     end
 
     if isempty(all_positions)
-        GLA.unbind(plot_line_prog[])
         return
     end
 
@@ -164,9 +163,6 @@ function draw_lines(batch::LineBatch, projection_matrix::Mat4{Float32}; anti_ali
     GLA.bind(vao)
     GLA.draw(vao)
     GLA.unbind(vao)
-
-    # Unbind shader program
-    GLA.unbind(plot_line_prog[])
 end
 
 # Generate efficient line geometry - minimal triangles, optimized for performance

--- a/src/composite_components/plot/draw/marker_draw.jl
+++ b/src/composite_components/plot/draw/marker_draw.jl
@@ -67,9 +67,6 @@ function draw_markers(batch::MarkerBatch, projection_matrix::Mat4{Float32}; anti
     GLA.bind(vao)
     GLA.draw(vao)
     GLA.unbind(vao)
-
-    # Unbind shader program
-    GLA.unbind(marker_prog[])
 end
 
 """

--- a/src/composite_components/plot/draw/texture_draw.jl
+++ b/src/composite_components/plot/draw/texture_draw.jl
@@ -80,7 +80,6 @@ function draw_matrix_with_colormap(
         GLA.bind(vao)
         GLA.draw(vao)
         GLA.unbind(vao)
-        GLA.unbind(plot_image_prog[])
 
     catch e
         @warn "Failed to draw textured quad: $e"

--- a/test/colorbar_demo.jl
+++ b/test/colorbar_demo.jl
@@ -1,71 +1,71 @@
 using Fugl
 
 function colorbar_demo()
-        # Create sample data for heatmap
-        x_range = range(-2π, 2π, length=20)
-        y_range = range(-2π, 2π, length=20)
+    # Create sample data for heatmap
+    x_range = range(-2π, 2π, length=20)
+    y_range = range(-2π, 2π, length=20)
 
-        x_data = Float32.(collect(x_range))
-        y_data = Float32.(collect(y_range))
+    x_data = Float32.(collect(x_range))
+    y_data = Float32.(collect(y_range))
 
-        # Create 2D function data
-        z_data = Float32.([sin(x) * cos(y) for y in y_range, x in x_range])
+    # Create 2D function data
+    z_data = Float32.([sin(x) * cos(y) for y in y_range, x in x_range])
 
-        # Create main heatmap
-        heatmap = HeatmapElement(z_data, x_range=(x_data[1], x_data[end]), y_range=(y_data[1], y_data[end]), colormap=:viridis)
-        main_plot = Fugl.Plot([heatmap])
+    # Create main heatmap
+    heatmap = HeatmapElement(z_data, x_range=(x_data[1], x_data[end]), y_range=(y_data[1], y_data[end]), colormap=:viridis)
+    main_plot = Fugl.Plot([heatmap])
 
-        # Create vertical colorbar for the heatmap
-        vertical_colorbar = VerticalColorbar(heatmap)
+    # Create vertical colorbar for the heatmap
+    vertical_colorbar = VerticalColorbar(heatmap)
 
-        # Create horizontal colorbar for the heatmap
-        horizontal_colorbar = HorizontalColorbar(heatmap)
+    # Create horizontal colorbar for the heatmap
+    horizontal_colorbar = HorizontalColorbar(heatmap)
 
-        # Create UI layout examples
-        ui = Column([
-                        # Example 1: Plot with vertical colorbar on the right
-                        IntrinsicRow([
-                                        main_plot,
-                                        FixedWidth(Plot([vertical_colorbar], PlotStyle(
-                                                        show_left_axis=true,
-                                                        show_right_axis=true,
-                                                        show_top_axis=true,
-                                                        show_bottom_axis=true,
-                                                        show_x_ticks=false,
-                                                        show_y_ticks=true
-                                                )), 100.0f0)
-                                ], spacing=0.0
-                        ),
+    # Create UI layout examples
+    ui = Column([
+            # Example 1: Plot with vertical colorbar on the right
+            IntrinsicRow([
+                    main_plot,
+                    FixedWidth(Plot([vertical_colorbar], PlotStyle(
+                            show_left_axis=true,
+                            show_right_axis=true,
+                            show_top_axis=true,
+                            show_bottom_axis=true,
+                            show_x_ticks=false,
+                            show_y_ticks=true
+                        )), 100.0f0)
+                ], spacing=0.0
+            ),
 
-                        # Example 2: Plot with horizontal colorbar at bottom
-                        IntrinsicColumn([
-                                        main_plot,
-                                        FixedHeight(Plot([horizontal_colorbar], PlotStyle(
-                                                        show_left_axis=true,
-                                                        show_right_axis=true,
-                                                        show_top_axis=true,
-                                                        show_bottom_axis=true,
-                                                        show_x_ticks=true,
-                                                        show_y_ticks=false
-                                                )), 100.0f0)
-                                ], spacing=0.0
-                        ),
+            # Example 2: Plot with horizontal colorbar at bottom
+            IntrinsicColumn([
+                    main_plot,
+                    FixedHeight(Plot([horizontal_colorbar], PlotStyle(
+                            show_left_axis=true,
+                            show_right_axis=true,
+                            show_top_axis=true,
+                            show_bottom_axis=true,
+                            show_x_ticks=true,
+                            show_y_ticks=false
+                        )), 100.0f0)
+                ], spacing=0.0
+            ),
 
-                        # Example 3: Different colormap with custom styling
-                        IntrinsicRow([
-                                        Plot([HeatmapElement(z_data, x_range=(x_data[1], x_data[end]), y_range=(y_data[1], y_data[end]), colormap=:plasma)]),
-                                        FixedWidth(Plot([VerticalColorbar(:plasma, (-1.0f0, 1.0f0))], PlotStyle(
-                                                        show_left_axis=true,
-                                                        show_right_axis=true,
-                                                        show_top_axis=true,
-                                                        show_bottom_axis=true,
-                                                        show_x_ticks=false,
-                                                        show_y_ticks=true
-                                                )), 100.0f0)
-                                ], spacing=0.0
-                        ),], spacing=0.0, padding=0.0)
+            # Example 3: Different colormap with custom styling
+            IntrinsicRow([
+                    Plot([HeatmapElement(z_data, x_range=(x_data[1], x_data[end]), y_range=(y_data[1], y_data[end]), colormap=:plasma)]),
+                    FixedWidth(Plot([VerticalColorbar(:plasma, (-1.0f0, 1.0f0))], PlotStyle(
+                            show_left_axis=true,
+                            show_right_axis=true,
+                            show_top_axis=true,
+                            show_bottom_axis=true,
+                            show_x_ticks=false,
+                            show_y_ticks=true
+                        )), 100.0f0)
+                ], spacing=0.0
+            ),], spacing=0.0, padding=0.0)
 
-        return ui
+    return ui
 end
 
 # Run the demo


### PR DESCRIPTION
It turnes out that unbinding the prog after each draw call stops the graphics drivers from optimizing prog loading for the consecutive draw calls.